### PR TITLE
fixes following findings

### DIFF
--- a/code/Utilities/requirements.txt
+++ b/code/Utilities/requirements.txt
@@ -34,7 +34,7 @@ Jinja2==2.11.3
 lazy-object-proxy==1.4.3
 livereload==2.6.3
 lockfile==0.12.2
-lxml==4.6.2
+lxml>=4.6.3
 Markdown==3.3.3
 MarkupSafe==1.1.1
 msgpack==1.0.0
@@ -42,11 +42,11 @@ mypy-extensions==0.4.3
 packaging==20.4
 pbr==5.5.1
 pydash==4.8.0
-Pygments==2.7.2
+Pygments>=2.7.4
 pyparsing==2.4.7
 python-slugify==4.0.1
 pytz==2020.1
-PyYAML==5.3.1
+PyYAML>=5.4
 recommonmark==0.6.0
 requests==2.24.0
 requests-file==1.5.1


### PR DESCRIPTION
# lxml

CVE-2021-28957
moderate severity
Vulnerable versions: < 4.6.3
Patched version: 4.6.3
An XSS vulnerability was discovered in the python lxml clean module versions before 4.6.3. When disabling the safe_attrs_only and forms arguments, the Cleaner class does not remove the formaction attribute allowing for JS to bypass the sanitizer. A remote attacker could exploit this flaw to run arbitrary JS code on users who interact with incorrectly sanitized HTML. This issue is patched in lxml 4.6.3.

# PyYAML
CVE-2020-14343
moderate severity
Vulnerable versions: < 5.4
Patched version: 5.4
A vulnerability was discovered in the PyYAML library in versions before 5.4, where it is susceptible to arbitrary code execution when it processes untrusted YAML files through the full_load method or with the FullLoader loader. Applications that use the library to process untrusted input may be vulnerable to this flaw. This flaw allows an attacker to execute arbitrary code on the system by abusing the python/object/new constructor. This flaw is due to an incomplete fix for CVE-2020-1747.

# pygments
CVE-2021-27291
moderate severity
Vulnerable versions: >= 1.1, < 2.7.4
Patched version: 2.7.4
In pygments 1.1+, fixed in 2.7.4, the lexers used to parse programming languages rely heavily on regular expressions. Some of the regular expressions have exponential or cubic worst-case complexity and are vulnerable to ReDoS. By crafting malicious input, an attacker can cause a denial of service.